### PR TITLE
Rename init.py to __init__.py

### DIFF
--- a/wns/__init__.py
+++ b/wns/__init__.py
@@ -1,0 +1,1 @@
+from wnslib import WNSClient

--- a/wns/init.py
+++ b/wns/init.py
@@ -1,1 +1,0 @@
-from wnslib import WNSClient


### PR DESCRIPTION
Python expects packages to have an **init**.py file in the package directory;
if this file is not provided, the package cannot be included
