### PR TITLE
Cleanup

### DIFF
--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -184,10 +184,6 @@ class WNSBase(object):
 
         return status
 
-    def handle_response(self, response):
-        result = self.parse_response(response)
-        result['response'] = {'status': response.code, 'headers': dict(response.headers), 'text': response.body}
-
     def send(self, uri, payload):
         """
         Send push message. Input parameters:

--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -83,8 +83,8 @@ class WNSClient():
             wns = WNSRaw(accesstoken=self.accesstoken)
         else:
             raise WNSInvalidPushTypeException(wnstype)
-        result = wns.send(url, wnsparams)
-        return result
+
+        return wns.send(url, wnsparams)
 
     def request_token(self):
         payload = {'grant_type': 'client_credentials',
@@ -199,7 +199,7 @@ class WNSBase(object):
         """
         data = self.prepare_payload(payload)
         response = requests.post(uri, headers=self.headers, data=data)
-        return response
+        return self.parse_response(response)
 
 
 class WNSToast(WNSBase):

--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -165,6 +165,16 @@ class WNSBase(object):
             status['drop_subscription'] = True
         elif code == 405:
             status['error'] = 'Invalid Method'
+        elif code == 406:
+            status['error'] = 'Throttle limit exceeded'
+        elif code == 410:
+            status['error'] = 'Channel expired'
+            status['drop_subscription'] = True
+        elif code == 413:
+            status['error'] = 'Payload exceeds size limit'
+        elif code == 500:
+            status['error'] = 'Internal Server Error'
+            status['backoff_seconds'] = 60
         elif code == 503:
             status['error'] = 'Service Unavailable - try again later'
             status['backoff_seconds'] = 60

--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -26,12 +26,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import eventlet
-requests = eventlet.import_patched('requests.__init__')
-import requests
 import time
 import xml.etree.ElementTree as ET
 from cStringIO import StringIO
+import eventlet
+requests = eventlet.import_patched('requests.__init__')
+import requests  # NOQA
+
 try:
     register_namespace = ET.register_namespace
 except AttributeError:
@@ -39,7 +40,8 @@ except AttributeError:
         ET._namespace_map[uri] = prefix
 
 
-class WNSException(Exception): pass
+class WNSException(Exception):
+    pass
 
 
 class WNSInvalidPushTypeException(WNSException):
@@ -71,7 +73,7 @@ class WNSClient():
 
         if wnstype == 'toast':
             wnsparams.setdefault('template', 'ToastText01')
-            wns  = WNSToast(accesstoken=accesstoken)
+            wns = WNSToast(accesstoken=accesstoken)
         elif wnstype == 'tile':
             wnsparams.setdefault('template', 'TileSquare150x150Text01')
             wns = WNSTile(accesstoken=accesstoken)
@@ -80,7 +82,7 @@ class WNSClient():
             wns = WNSBadge(accesstoken=accesstoken)
         elif wnstype == 'raw':
             wnsparams.setdefault('raw', 'raw notification')
-            wns  = WNSRaw(accesstoken=accesstoken)
+            wns = WNSRaw(accesstoken=accesstoken)
         else:
             raise WNSInvalidPushTypeException(wnstype)
         result = wns.send(url, wnsparams)
@@ -229,6 +231,7 @@ class WNSToast(WNSBase):
                 count += 1
         return self.serialize_tree(ET.ElementTree(root))
 
+
 class WNSRaw(WNSBase):
     HEADER_CONTENT_TYPE = 'Content-Type'
     HEADER_X_NOTIFICATION = "X-NotificationClass"
@@ -245,6 +248,7 @@ class WNSRaw(WNSBase):
 
     def prepare_payload(self, payload):
         return payload['raw']
+
 
 class WNSTile(WNSBase):
     def __init__(self, *args, **kwargs):

--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -31,7 +31,6 @@ import xml.etree.ElementTree as ET
 from cStringIO import StringIO
 import eventlet
 requests = eventlet.import_patched('requests.__init__')
-import requests  # NOQA
 
 try:
     register_namespace = ET.register_namespace

--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -145,7 +145,7 @@ class WNSBase(object):
             'status': response.headers.get('X-WNS-Status', '')
         }
 
-        code = response.code
+        code = response.status_code
         status['http_status_code'] = code
 
         if code == 200:


### PR DESCRIPTION
While testing with the library, we found that several statuses returned by the WNS were not handled. 

When trying to look into the returned statuses, we realized that the WNSClient returned the raw request object, not the parsed one - and as no reference to WNS\* object was returned, parsing the response with the parse_response method wasn't possible, either. So we decided to return the parsed response.

We also noticed that for every notification the access token would be requested again, so we modified the behavior to keep the access token once requested and renew it when required.
