### PR TITLE
Export WNS exceptions

### DIFF
--- a/wns/__init__.py
+++ b/wns/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import absolute_import
-from .wnslib import WNSClient
+from .wnslib import WNSClient, WNSException, WNSInvalidPushTypeException


### PR DESCRIPTION
Unless these exceptions are exported from the module, they cannot be imported by consumers and hence not caught there 😬 