### PR TITLE
Fixed `Content-Length` header to be of type `str`

### DIFF
--- a/wns/wnslib.py
+++ b/wns/wnslib.py
@@ -115,7 +115,7 @@ class WNSBase(object):
         self.timeout = timeout
         self.headers = {
             'Content-Type': 'text/xml',
-            'Content-Length': len(self.accesstoken),
+            'Content-Length': str(len(self.accesstoken)),
             'Authorization': 'Bearer %s' % self.accesstoken,
         }
 


### PR DESCRIPTION
Requests library fails validation if this is of type `int`.